### PR TITLE
Include webhook and bot running instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,26 @@ in a new file called .env in root dir.
 
 Finally, set the webhook for your server by CURL-ing the Telegram API.
 
+This can be done by running the following cURL command :
+
+```
+curl https://api.telegram.org/bot<token>/setWebhook \
+    -F "url=<forwarding url>"
+```
+
+Replace ```token``` with your Bot Token, and ```forwarding url``` with your webhook url.
+
+Example :
+```
+curl https://api.telegram.org/bot14532169:JksmKMS975SAYoUrT0k3NdqiqNS84nSUD89e/setWebhook \
+    -F "url=https://ce8b-1115-111-1109-1179-1130-1124-1187-117e.ngrok.io"
+```
+
+Once all of this is done, run the bot by running the command :
+
+```
+go run main.go
+```
+
 > Also use **go mod vendor** to download libraries in root folder for deployment. I used Heroku for deployment.
 


### PR DESCRIPTION
The readme mentions about webhooks but does not specify what commands need to be used. This fixed that problem by mentioning the additional required details.